### PR TITLE
Remove name from adb config create --from-json and make consistent

### DIFF
--- a/notebooks/semantic_search/cohere_wikipedia_ingest.ipynb
+++ b/notebooks/semantic_search/cohere_wikipedia_ingest.ipynb
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! adb config create rag --from-json --active "
+    "! adb config create --from-json --active "
    ]
   },
   {

--- a/notebooks/semantic_search/cohere_wikipedia_search.ipynb
+++ b/notebooks/semantic_search/cohere_wikipedia_search.ipynb
@@ -475,12 +475,6 @@
     "\n",
     "If you'd like to try assembling your own RAG corpus by crawling a website, see [Ingesting a Website into ApertureDB](website_ingest)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3cdd0842",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/semantic_search/cohere_wikipedia_search.ipynb
+++ b/notebooks/semantic_search/cohere_wikipedia_search.ipynb
@@ -173,15 +173,26 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
+   "cell_type": "markdown",
    "id": "3f8c4efa",
+   "metadata": {},
+   "source": [
+    "## Connect to ApertureDB\n",
+    "\n",
+    "For the next part, we need access to a specific ApertureDB instance.\n",
+    "There are several ways to set this up.\n",
+    "The code provided here will accept ApertureDB connection information as a JSON string.\n",
+    "See our [Configuration](https://docs.aperturedata.io/Setup/client/configuration) help page for more options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbce988c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from getpass import getpass\n",
-    "os.environ['APERTUREDB_JSON'] = getpass()"
+    "! adb config create --from-json --active "
    ]
   },
   {

--- a/notebooks/semantic_search/website_ingest.ipynb
+++ b/notebooks/semantic_search/website_ingest.ipynb
@@ -174,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! adb config create rag --from-json --active "
+    "! adb config create --from-json --active "
    ]
   },
   {

--- a/notebooks/semantic_search/website_search.ipynb
+++ b/notebooks/semantic_search/website_search.ipynb
@@ -169,21 +169,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "c07f7cce",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2;36m[18:40:42]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;33mConfiguration named \u001b[0m\u001b[32m'rag'\u001b[0m\u001b[1;33m already exists. Use       \u001b[0m \u001b]8;id=50467;file:///home/gavin/github/aperturedb-python/aperturedb/cli/configure.py\u001b\\\u001b[2mconfigure.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=547373;file:///home/gavin/github/aperturedb-python/aperturedb/cli/configure.py#140\u001b\\\u001b[2m140\u001b[0m\u001b]8;;\u001b\\\n",
-      "\u001b[2;36m           \u001b[0m\u001b[1;33m--overwrite to overwrite.                           \u001b[0m \u001b[2m                \u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "! adb config create rag --from-json --active "
+    "! adb config create  --from-json --active "
    ]
   },
   {


### PR DESCRIPTION
Now that the name is optional with `--from-json`, tidy up a few remaining cases, and fix one notebook to be the same as the others.